### PR TITLE
[뉴스 제목 체크박스 클릭 시 해당 기사 본문을  tabloid.tsx props로 넘겨줌]

### DIFF
--- a/dist/client/components/articleList.js
+++ b/dist/client/components/articleList.js
@@ -31,27 +31,36 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 var React = __importStar(require("react"));
+var tabloid_1 = __importDefault(require("./tabloid"));
 require("./articleList.css");
 var ArticleList = /** @class */ (function (_super) {
     __extends(ArticleList, _super);
     function ArticleList(props) {
         var _this = _super.call(this, props) || this;
-        _this.state = {
-            // selectedArticles: [],
-            chkbox: false,
-        };
+        _this.state = {};
         return _this;
         // this.onCheckChange = this.onCheckChange.bind(this);
     }
     ArticleList.prototype.render = function () {
-        // let Nodelists: any = document.querySelectorAll(".select-checkbox");
-        // console.log("Nodelists: ", Nodelists);
-        var onCheckChange = function (e) { };
-        return (React.createElement("li", { className: "article-title", onChange: onCheckChange },
-            React.createElement("input", { className: "select-checkbox", type: "checkbox", defaultChecked: this.state.chkbox }),
-            this.props.news.title));
+        var _this = this;
+        var checkedBox = this.props.checkedBox;
+        console.log(checkedBox);
+        var handleCheck = function (e) {
+            var checkbox = document.querySelectorAll("input[type='checkbox']:checked");
+            {
+                _this.props.news.description;
+            }
+        };
+        return (React.createElement("div", null,
+            React.createElement("li", { className: "article-title" },
+                React.createElement("input", { className: "select-checkbox", type: "checkbox", key: "key" }),
+                this.props.news.title),
+            React.createElement(tabloid_1.default, { checkedBox: this.props.checkedBox })));
     };
     return ArticleList;
 }(React.Component));

--- a/dist/client/components/searchBar.js
+++ b/dist/client/components/searchBar.js
@@ -47,12 +47,12 @@ var SearchBar = /** @class */ (function (_super) {
             // Nodelists.forEach((value: Node, key: number, parent: NodeList): void => {
             //   value.DOCUMENT_NODE.
             // })
-            var allCheckBoxes = document.querySelectorAll("input[type='checkbox']");
-            allCheckBoxes.forEach(function (checkBox) {
-                console.log(checkBox);
-                if (checkBox && checkBox.checked)
-                    checkBox.checked = true;
-            });
+            var allCheckBoxes = document.querySelectorAll("input[type='checkbox']:checked");
+            console.log("allCheckBoxes: ", allCheckBoxes);
+            _this.setState({ checkedBox: allCheckBoxes });
+        };
+        _this.state = {
+            checkedBox: null,
         };
         _this.onCheckChange = _this.onCheckChange.bind(_this);
         return _this;
@@ -66,7 +66,7 @@ var SearchBar = /** @class */ (function (_super) {
                     React.createElement("button", { className: "searchBtn", type: "submit" }, "\uAC80\uC0C9")),
                 React.createElement("div", { className: "newsList" },
                     React.createElement("ul", { className: "article-list", onChange: this.onCheckChange }, this.props.articles.map(function (contact, idx) {
-                        return (React.createElement(articleList_1.default, { news: contact, key: idx, limit: _this.props.limit, count: _this.props.count }));
+                        return (React.createElement(articleList_1.default, { news: contact, key: idx, limit: _this.props.limit, count: _this.props.count, checkedBox: _this.state.checkedBox }));
                     }))))));
     };
     return SearchBar;

--- a/dist/client/components/tabloid.js
+++ b/dist/client/components/tabloid.js
@@ -1,1 +1,54 @@
 "use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var React = __importStar(require("react"));
+require("./searchBar.css");
+var Tabloid = /** @class */ (function (_super) {
+    __extends(Tabloid, _super);
+    function Tabloid(props) {
+        var _this = _super.call(this, props) || this;
+        _this.state = {};
+        return _this;
+    }
+    Tabloid.prototype.render = function () {
+        var checkBox = this.props.checkedBox;
+        // if (checkBox !== null) {
+        //   checkBox.forEach((el) => console.log(el.key));
+        // }
+        return (React.createElement("div", null,
+            React.createElement("div", null)));
+    };
+    return Tabloid;
+}(React.Component));
+exports.default = Tabloid;

--- a/src/client/components/articleList.tsx
+++ b/src/client/components/articleList.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Tbloid from "./tabloid";
 import "./articleList.css";
 
 interface ListProps {
@@ -9,9 +10,11 @@ interface ListProps {
     description: string;
     pubDate: string;
   };
+  checkedBox: NodeListOf<HTMLInputElement> | null;
   key: number;
   limit: number;
   count: number;
+  showArticleBody: any;
 }
 
 interface ListState {}
@@ -20,15 +23,37 @@ export default class ArticleList extends React.Component<ListProps, ListState> {
   constructor(props: ListProps) {
     super(props);
     this.state = {};
-    // this.onCheckChange = this.onCheckChange.bind(this);
+    // this.handleChange = this.handleChange.bind(this);
   }
 
   render() {
+    const checkedBox = this.props.checkedBox;
+    console.log(checkedBox);
+    let articleBody: any;
+
+    const handleCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
+      let checkCbx: NodeListOf<Element> = document.querySelectorAll(
+        "input[type='checkbox']:checked"
+      );
+      if (e.target.checked) {
+        // articleBody = <Tbloid news={this.props.news}></Tbloid>;
+        const slectedArticle = this.props.news;
+        this.props.showArticleBody(slectedArticle);
+      }
+    };
     return (
-      <li className="article-title">
-        <input className="select-checkbox" type="checkbox" />
-        {this.props.news.title}
-      </li>
+      <div>
+        <li className="article-title">
+          <input
+            className="select-checkbox"
+            type="checkbox"
+            key="key"
+            onChange={handleCheck}
+          />
+          {this.props.news.title}
+        </li>
+        {articleBody}
+      </div>
     );
   }
 }

--- a/src/client/components/searchBar.tsx
+++ b/src/client/components/searchBar.tsx
@@ -3,7 +3,6 @@ import { Link, Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import Sidebar from "react-sidebar";
 import axios from "axios";
 import ArticleList from "./articleList";
-import Tbloid from "./tabloid";
 import "./searchBar.css";
 
 interface searchProps {
@@ -21,7 +20,7 @@ interface searchProps {
   count: number;
   handleSubmitSearching: any;
   handleChangeKeyword: any;
-  // onCheckChange: any;
+  showArticleBody: any;
 }
 
 interface searchState {
@@ -80,13 +79,13 @@ export default class SearchBar extends React.Component<
                     key={idx}
                     limit={this.props.limit}
                     count={this.props.count}
-                    // onCheckChange={this.onCheckChange}
+                    checkedBox={this.state.checkedBox}
+                    showArticleBody={this.props.showArticleBody}
                   />
                 );
               })}
             </ul>
           </div>
-          <Tbloid checkedBox={this.state.checkedBox}></Tbloid>
         </React.Fragment>
       </div>
     );

--- a/src/client/components/sideBar.tsx
+++ b/src/client/components/sideBar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Link, Route, Switch, BrowserRouter, Router } from "react-router-dom";
 import axios from "axios";
 import SearchBar from "./searchBar";
+import Tabloid from "./tabloid";
 import "./sideBar.css";
 
 interface SidebarProps {}
@@ -21,7 +22,13 @@ interface SidebarState {
     description: string;
     pubDate: string;
   }[];
-  //   selectedArticles: {}[];
+  selectedArticles: {
+    title: string;
+    originallink: string;
+    link: string;
+    description: string;
+    pubDate: string;
+  }[];
 }
 
 export class Sidebar extends React.Component<SidebarProps, SidebarState> {
@@ -36,6 +43,7 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
       count: 0,
       checked: 0,
       articles: [],
+      selectedArticles: [],
     };
 
     this.handleCloseToggle = this.handleCloseToggle.bind(this);
@@ -76,6 +84,15 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
     console.log(this.state);
   };
 
+  showArticleBody = (
+    // event: React.ChangeEvent<HTMLInputElement>,
+    slectedArticle: any
+  ): void => {
+    this.setState((prevState: Readonly<any>) => ({
+      selectedArticles: [...(prevState.selectedArticles ?? []), slectedArticle],
+    }));
+  };
+
   render() {
     const transform = this.state.transform;
     console.log(transform);
@@ -103,6 +120,7 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
                   count={this.state.count}
                   handleSubmitSearching={this.handleSubmitSearching}
                   handleChangeKeyword={this.handleChangeKeyword}
+                  showArticleBody={this.showArticleBody}
                   //   onCheckChange={this.onCheckChange}
                 />
               </div>
@@ -116,6 +134,9 @@ export class Sidebar extends React.Component<SidebarProps, SidebarState> {
                 }}
                 onClick={this.handleCloseToggle}
               ></div>
+            </th>
+            <th>
+              <Tabloid news={this.state.selectedArticles}></Tabloid>
             </th>
           </tr>
         </tbody>

--- a/src/client/components/tabloid.tsx
+++ b/src/client/components/tabloid.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Link, Route, Switch, BrowserRouter as Router } from "react-router-dom";
+import "./searchBar.css";
+
+interface tabloidProps {
+  // checkedBox: NodeListOf<HTMLInputElement> | null;
+  news: {
+    title: string;
+    originallink: string;
+    link: string;
+    description: string;
+    pubDate: string;
+  }[];
+}
+
+interface tabloidState {}
+
+export default class Tabloid extends React.Component<
+  tabloidProps,
+  tabloidState
+> {
+  constructor(props: tabloidProps) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <div></div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
- checkbox의 변경사항을 article.tsx에서 감지해서 sideBar.tsx의 state를 변경하는 함수 실행
- taloid 컴포넌트의 위치를 article -> sideBar 컴포넌트 밑으로 옮김
sideBar에서 table 포맷으로 searchBar, toggleBar, tabloid를 구분해서 랜더할 수 있게 변경함